### PR TITLE
Update Java 8 JDK link to 1.8.0_171

### DIFF
--- a/NetBeansJavaSEPortable/App/JDK/README.txt
+++ b/NetBeansJavaSEPortable/App/JDK/README.txt
@@ -1,6 +1,6 @@
 
 Please download a copy of the JDK, and save into this folder.
 
-  Java 8 - http://installbuilder.bitrock.com/java/jre1.8.0_171-windows.zip
+  Java 8 - http://installbuilder.bitrock.com/java/jdk1.8.0_171-windows.zip
   Java 7 - http://installbuilder.bitrock.com/java/jdk1.7.0_79-windows.zip
   Java 6 - http://installbuilder.bitrock.com/java/jdk1.6.0_45-windows.zip

--- a/NetBeansJavaSEPortable/App/JDK/README.txt
+++ b/NetBeansJavaSEPortable/App/JDK/README.txt
@@ -1,6 +1,6 @@
 
 Please download a copy of the JDK, and save into this folder.
 
-  Java 8 - http://installbuilder.bitrock.com/java/jdk1.8.0_121-windows.zip
+  Java 8 - http://installbuilder.bitrock.com/java/jre1.8.0_171-windows.zip
   Java 7 - http://installbuilder.bitrock.com/java/jdk1.7.0_79-windows.zip
   Java 6 - http://installbuilder.bitrock.com/java/jdk1.6.0_45-windows.zip

--- a/NetBeansPortable/App/JDK/README.txt
+++ b/NetBeansPortable/App/JDK/README.txt
@@ -1,6 +1,6 @@
 
 Please download a copy of the JDK, and save into this folder.
 
-  Java 8 - http://installbuilder.bitrock.com/java/jre1.8.0_171-windows.zip
+  Java 8 - http://installbuilder.bitrock.com/java/jdk1.8.0_171-windows.zip
   Java 7 - http://installbuilder.bitrock.com/java/jdk1.7.0_79-windows.zip
   Java 6 - http://installbuilder.bitrock.com/java/jdk1.6.0_45-windows.zip

--- a/NetBeansPortable/App/JDK/README.txt
+++ b/NetBeansPortable/App/JDK/README.txt
@@ -1,6 +1,6 @@
 
 Please download a copy of the JDK, and save into this folder.
 
-  Java 8 - http://installbuilder.bitrock.com/java/jdk1.8.0_121-windows.zip
+  Java 8 - http://installbuilder.bitrock.com/java/jre1.8.0_171-windows.zip
   Java 7 - http://installbuilder.bitrock.com/java/jdk1.7.0_79-windows.zip
   Java 6 - http://installbuilder.bitrock.com/java/jdk1.6.0_45-windows.zip


### PR DESCRIPTION
The old link for 1.8.0_121 is no longer valid.